### PR TITLE
Исправлена ошибка, из-за которой в errorBlock запросов приходила пустая ошибка

### DIFF
--- a/library/Source/Core/VKRequest.m
+++ b/library/Source/Core/VKRequest.m
@@ -428,8 +428,8 @@ void vksdk_dispatch_on_main_queue_now(void(^block)(void)) {
                     postRequest.errorBlock(self.error);
                 }
             }
+            self.error = nil;
         };
-        self.error = nil;
     } else {
         block = ^{
             if (self.completeBlock) {


### PR DESCRIPTION
Сначала ошибка обнулялась и только потом вызывался errorBlock. 